### PR TITLE
Add support for daily builds of latest release tag and push to image registry

### DIFF
--- a/.github/workflows/docker-schedule.yml
+++ b/.github/workflows/docker-schedule.yml
@@ -1,0 +1,51 @@
+# This workflow is triggered by a scheduled event and builds and pushes a Docker image to the GitHub Container Registry.
+# Workflow exists to ensure that the image is rebuilt periodically to include most recent security updates.
+
+name: Daily Docker image build to include security updates
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  push_to_latest_release:
+    name: Push latest Docker image to registry based on last release version
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: | 
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.tags }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          build-args: |
+            BASE_ALGORAND_IMAGE=${{ steps.meta.outputs.tags }}
+          # Set push to false until ready to merge in
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}, latest
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This should ensure that latest updates are pulled in from base algorand image, as well as ensure we always remediate CVE's as fixes becomes available.